### PR TITLE
Use addFieldToTab with a single field to prevent TypeError

### DIFF
--- a/src/Extensions/RecaptchaV3RuleExtension.php
+++ b/src/Extensions/RecaptchaV3RuleExtension.php
@@ -32,7 +32,7 @@ class RecaptchaV3RuleExtension extends \SilverStripe\Core\Extension
         $field->setConfig($config);
 
         if ($field) {
-            $fields->addFieldsToTab(
+            $fields->addFieldToTab(
                 'Root.FormFields',
                 $field
             );


### PR DESCRIPTION
This updates the implementation to use add**Field**ToTab with a single field argument instead of add**Fields**ToTab, which expects an array.

It prevents an Uncaught TypeError, as addFieldsToTab does not accept a single field. Switching to the correct method resolves the issue.